### PR TITLE
Fix: reduce hover flicker

### DIFF
--- a/specificities-overlap.js
+++ b/specificities-overlap.js
@@ -1,0 +1,36 @@
+var specificity = require('./specificity');
+
+function specificitiesOverlap(selector1, selector2, cache) {
+  var specificity1;
+  var specificity2;
+  var i, l;
+  var j, m;
+
+  for (i = 0, l = selector1.length; i < l; i++) {
+    specificity1 = findSpecificity(selector1[i][1], cache);
+
+    for (j = 0, m = selector2.length; j < m; j++) {
+      specificity2 = findSpecificity(selector2[j][1], cache);
+
+      if (specificity1[0] === specificity2[0]
+        && specificity1[1] === specificity2[1]
+        && specificity1[2] === specificity2[2]) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+function findSpecificity(selector, cache) {
+  var value;
+
+  if (!(selector in cache)) {
+    cache[selector] = value = specificity(selector);
+  }
+
+  return value || cache[selector];
+}
+
+module.exports = specificitiesOverlap;


### PR DESCRIPTION
Reduce hover flicker on primary buttons by replacing the layout-affecting outline with a non-layout box-shadow transition. This prevents reflow on hover and adds -webkit-tap-highlight-color: transparent to avoid tap flash on mobile.